### PR TITLE
add mcp server for agentic pipeline orchestration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,15 @@ dependencies = [
     "pandas",
     "requests",
     "typer[all]",
+    "fastmcp",
 ]
+
+[project.optional-dependencies]
+cloudos = ["cloudos-cli"]
 
 [project.scripts]
 cellxgene-harvester = "harvester.cli:main"
+cellxgene-harvester-mcp = "harvester.mcp.server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/harvester/mcp/__init__.py
+++ b/src/harvester/mcp/__init__.py
@@ -1,0 +1,1 @@
+# MCP server package for cellxgene-harvester

--- a/src/harvester/mcp/cloudos_client.py
+++ b/src/harvester/mcp/cloudos_client.py
@@ -1,0 +1,206 @@
+"""
+CloudOS client for dispatching Step 5 (count_normal_cells) to Lifebit CloudOS.
+
+This module submits a Nextflow job to CloudOS and polls for completion.
+Steps 0-4 and 6 run locally inside the MCP server process; only Step 5
+is dispatched to CloudOS because of its memory requirements (CellxGene Census).
+
+Prerequisites
+-------------
+Set these environment variables before starting the MCP server:
+
+  CLOUDOS_API_KEY       CloudOS API key (Settings > API in CloudOS UI)
+  CLOUDOS_WORKSPACE_ID  Workspace / team ID
+  CLOUDOS_PROJECT_ID    Project ID where jobs will run
+  CLOUDOS_WORKFLOW_ID   ID of the count_normal_cells Nextflow workflow in CloudOS
+
+Optional:
+  CLOUDOS_URL           CloudOS instance URL (default: https://cloudos.lifebit.ai)
+
+The Nextflow workflow referenced by CLOUDOS_WORKFLOW_ID must already be
+configured in CloudOS. It should scatter count_normal_cells_single.py across
+datasets in the input CSV and collect results into a single output CSV.
+See nextflow/count_normal_cells.nf for the workflow definition.
+
+Install the client library:
+  pip install cloudos-cli
+
+NIH migration note
+------------------
+When moving to NIH NLM servers, replace the CloudOS job dispatch with NIH HPC
+submission (e.g., SLURM via biowulf) or local execution on NIH-provisioned
+high-memory nodes. The interface here stays the same; only the implementation
+of submit_count_normal_cells() changes.
+"""
+
+import os
+import sys
+import time
+
+CLOUDOS_URL_DEFAULT = "https://cloudos.lifebit.ai"
+POLL_INTERVAL_SECONDS = 30
+MAX_POLL_ATTEMPTS = 120  # polls for up to 60 minutes
+
+
+def is_configured() -> bool:
+    """Return True if all required CloudOS environment variables are set."""
+    required = [
+        "CLOUDOS_API_KEY",
+        "CLOUDOS_WORKSPACE_ID",
+        "CLOUDOS_PROJECT_ID",
+        "CLOUDOS_WORKFLOW_ID",
+    ]
+    return all(os.environ.get(k) for k in required)
+
+
+def _get_config() -> dict:
+    return {
+        "api_key": os.environ["CLOUDOS_API_KEY"],
+        "url": os.environ.get("CLOUDOS_URL", CLOUDOS_URL_DEFAULT),
+        "workspace_id": os.environ["CLOUDOS_WORKSPACE_ID"],
+        "project_id": os.environ["CLOUDOS_PROJECT_ID"],
+        "workflow_id": os.environ["CLOUDOS_WORKFLOW_ID"],
+    }
+
+
+def _get_cloudos_client(cfg: dict):
+    """Instantiate the cloudos-cli Cloudos object. Raises ImportError if not installed."""
+    try:
+        from cloudos.utils.cloudos import Cloudos  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(
+            "cloudos-cli is required for CloudOS job dispatch. "
+            "Install it with: pip install 'cellxgene-harvester[cloudos]'"
+        ) from exc
+    return Cloudos(cloudos_url=cfg["url"], apikey=cfg["api_key"], cromwell_token=None)
+
+
+def submit_count_normal_cells(
+    input_csv_path: str,
+    uberon_json_path: str,
+    min_age: int = 15,
+    job_name: str = "count-normal-cells",
+) -> str:
+    """Submit a count_normal_cells Nextflow job to CloudOS.
+
+    Parameters
+    ----------
+    input_csv_path:   Path (cloud storage URI or local path mounted by CloudOS)
+                      to the filtered datasets CSV from Step 4.
+    uberon_json_path: Path to the UBERON JSON produced by Step 0.
+    min_age:          Minimum donor age for adult filtering (default 15).
+    job_name:         Display name for the job in CloudOS.
+
+    Returns
+    -------
+    str: The CloudOS job ID (used to poll status).
+
+    Notes
+    -----
+    Input files must be accessible from the CloudOS compute environment.
+    If they are local files, upload them to cloud storage (S3/GCS) first
+    and pass the cloud URIs here.
+    """
+    cfg = _get_config()
+    client = _get_cloudos_client(cfg)
+
+    # cloudos-cli job submission API
+    # See: https://github.com/lifebit-ai/cloudos-cli
+    job_params = [
+        {"name": "input_csv",   "value": input_csv_path},
+        {"name": "uberon_json", "value": uberon_json_path},
+        {"name": "min_age",     "value": str(min_age)},
+    ]
+
+    response = client.job_submit(
+        workflow_id=cfg["workflow_id"],
+        project_id=cfg["project_id"],
+        workspace_id=cfg["workspace_id"],
+        job_name=job_name,
+        job_params=job_params,
+    )
+
+    job_id = response.get("_id") or response.get("id") or response.get("jobId")
+    if not job_id:
+        raise RuntimeError(f"CloudOS job submission did not return a job ID. Response: {response}")
+
+    print(f"[CloudOS] Submitted job '{job_name}' → job_id={job_id}", file=sys.stderr)
+    return job_id
+
+
+def wait_for_completion(job_id: str) -> dict:
+    """Poll CloudOS until the job reaches a terminal state.
+
+    Parameters
+    ----------
+    job_id: The job ID returned by submit_count_normal_cells().
+
+    Returns
+    -------
+    dict with at least:
+      status:      "completed" | "failed" | "cancelled"
+      output_path: cloud path to the output CSV (if completed successfully)
+
+    Raises
+    ------
+    RuntimeError:  If the job fails or is cancelled.
+    TimeoutError:  If the job does not finish within MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS.
+    """
+    cfg = _get_config()
+    client = _get_cloudos_client(cfg)
+
+    terminal_states = {"completed", "failed", "cancelled", "aborted"}
+
+    for attempt in range(1, MAX_POLL_ATTEMPTS + 1):
+        status_info = client.get_job_status(
+            job_id=job_id, workspace_id=cfg["workspace_id"]
+        )
+        status = (status_info.get("status") or "unknown").lower()
+
+        print(
+            f"[CloudOS] Job {job_id}: {status} (poll {attempt}/{MAX_POLL_ATTEMPTS})",
+            file=sys.stderr,
+        )
+
+        if status in terminal_states:
+            if status != "completed":
+                raise RuntimeError(
+                    f"CloudOS job {job_id} ended with status '{status}'. "
+                    f"Check the CloudOS dashboard for logs."
+                )
+            return status_info
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    raise TimeoutError(
+        f"CloudOS job {job_id} did not complete within "
+        f"{MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS // 60} minutes."
+    )
+
+
+def run_via_cloudos(
+    input_csv_path: str,
+    uberon_json_path: str,
+    min_age: int = 15,
+    job_name: str = "count-normal-cells",
+) -> dict:
+    """Submit and wait for a count_normal_cells CloudOS job.
+
+    Returns a dict with:
+      job_id:      CloudOS job ID
+      status:      "completed"
+      output_path: path/URI of the output CSV (from CloudOS status response)
+    """
+    job_id = submit_count_normal_cells(
+        input_csv_path=input_csv_path,
+        uberon_json_path=uberon_json_path,
+        min_age=min_age,
+        job_name=job_name,
+    )
+    status_info = wait_for_completion(job_id)
+    return {
+        "job_id": job_id,
+        "status": "completed",
+        "output_path": status_info.get("outputPath") or status_info.get("output_path", ""),
+        "cloudos_details": status_info,
+    }

--- a/src/harvester/mcp/server.py
+++ b/src/harvester/mcp/server.py
@@ -1,0 +1,366 @@
+"""
+MCP server for cellxgene-harvester.
+
+Exposes each pipeline step as an MCP tool so AI agents (Claude Code,
+Claude Desktop, etc.) can orchestrate the full pipeline through natural language.
+
+Steps 0-4 and 6 run in-process (lightweight API calls).
+Step 5 (count_normal_cells) dispatches to Lifebit CloudOS when
+CLOUDOS_API_KEY and related env vars are configured; otherwise it
+runs locally (useful for development and small datasets).
+
+Usage
+-----
+Start the server (stdio transport for Claude Code / Claude Desktop):
+
+    cellxgene-harvester-mcp
+
+Configure in ~/.claude.json (Claude Code):
+
+    {
+      "mcpServers": {
+        "cellxgene-harvester": {
+          "command": "cellxgene-harvester-mcp",
+          "env": {
+            "CLOUDOS_API_KEY": "<your-key>",
+            "CLOUDOS_WORKSPACE_ID": "<workspace-id>",
+            "CLOUDOS_PROJECT_ID": "<project-id>",
+            "CLOUDOS_WORKFLOW_ID": "<nextflow-workflow-id>"
+          }
+        }
+      }
+    }
+
+NIH migration note
+------------------
+To deploy as a remote HTTP/SSE server on NIH NLM infrastructure, change
+the main() call to:
+
+    mcp.run(transport="sse", host="0.0.0.0", port=8000)
+
+All tool logic stays the same; only the transport layer changes.
+"""
+
+import io
+import os
+import re
+import sys
+from contextlib import redirect_stdout
+from typing import Optional
+
+from fastmcp import FastMCP
+
+mcp = FastMCP(
+    "cellxgene-harvester",
+    instructions=(
+        "Pipeline for harvesting normal cells from CellxGene Census. "
+        "Run steps in order: resolve_uberon → fetch_collections → "
+        "generate_metadata → append_dataset_details → filter_datasets → "
+        "count_normal_cells → final_cleanup. "
+        "Each tool returns the output file path(s) to pass into the next step."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _run(func, *args, **kwargs):
+    """Call a harvester run_*() function, routing its stdout to stderr.
+
+    The MCP stdio protocol uses stdout; any print() calls from harvester
+    functions would corrupt the protocol. This helper captures stdout and
+    re-emits it on stderr so it appears in server logs without affecting
+    the MCP channel.
+    """
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result = func(*args, **kwargs)
+    output = buf.getvalue()
+    if output:
+        print(output, file=sys.stderr, end="")
+    return result
+
+
+def _uberon_prefix(queries: list[str], output_prefix: Optional[str]) -> str:
+    """Replicate resolve_uberon.py's prefix logic so the tool can return paths."""
+    if output_prefix:
+        return output_prefix
+    slug = re.sub(r"[^a-z0-9]+", "_", queries[0].lower()).strip("_")
+    return os.path.join("data", f"uberon_{slug}")
+
+
+# ---------------------------------------------------------------------------
+# Step 0 — Resolve UBERON terms
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def resolve_uberon(
+    queries: list[str],
+    output_prefix: Optional[str] = None,
+    multi: bool = False,
+) -> dict:
+    """Step 0: Resolve tissue labels or UBERON IDs to descendant ontology terms.
+
+    Queries the OLS4 API to find all hierarchical descendants of each term,
+    then writes JSON and CSV files for use in filter_datasets and count_normal_cells.
+
+    Parameters
+    ----------
+    queries:       One or more tissue labels (e.g. ["kidney"]) or UBERON IDs
+                   (e.g. ["UBERON:0002113"]).
+    output_prefix: File path prefix for output files (without extension).
+                   Defaults to data/uberon_<tissue>.
+    multi:         If True, combine all queries into a single output file.
+
+    Returns
+    -------
+    json_file: Path to the UBERON JSON (pass to filter_datasets and count_normal_cells).
+    csv_file:  Path to the flat ontology CSV.
+    """
+    from harvester.resolve_uberon import run_resolve_uberon  # noqa: PLC0415
+
+    _run(run_resolve_uberon, queries, output_prefix, multi)
+
+    prefix = _uberon_prefix(queries, output_prefix)
+    return {
+        "json_file": f"{prefix}.json",
+        "csv_file": f"{prefix}.csv",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Fetch collections
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def fetch_collections() -> dict:
+    """Step 1: Fetch all public collections from the CellxGene API.
+
+    Downloads collection metadata (IDs, names, associated datasets) and
+    saves it locally. No arguments required.
+
+    Returns
+    -------
+    output_file: Path to the saved collections JSON.
+    """
+    from harvester.fetch_collections import run_fetch_collections  # noqa: PLC0415
+
+    _run(run_fetch_collections)
+    return {"output_file": "data/collections_metadata.json"}
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Generate metadata CSV
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def generate_metadata() -> dict:
+    """Step 2: Parse the collections JSON and generate a base metadata CSV.
+
+    Reads data/collections_metadata.json (from fetch_collections), selects
+    the latest version of each dataset, and writes a CSV with ~40 metadata
+    fields including publication info, tissue, assay, and ontology columns.
+
+    Returns
+    -------
+    output_file: Path to the generated metadata CSV.
+    """
+    from harvester.generate_metadata import run_generate_metadata  # noqa: PLC0415
+
+    _run(run_generate_metadata)
+    return {"output_file": "data/all_datasets.csv"}
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Append dataset details
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def append_dataset_details() -> dict:
+    """Step 3: Enrich the metadata CSV with per-dataset details from the CellxGene API.
+
+    For each dataset in data/all_datasets.csv, fetches: title, total cell
+    count, H5AD download URL, and Explorer URL. Rate-limited to be polite
+    to the CellxGene API (0.2 s between requests).
+
+    Returns
+    -------
+    output_file: Path to the enriched CSV.
+    """
+    from harvester.append_dataset_details import run_append_details  # noqa: PLC0415
+
+    _run(run_append_details)
+    return {"output_file": "data/all_datasets_complete.csv"}
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — Filter datasets
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def filter_datasets(
+    output_csv: str,
+    input_csv: str = "data/all_datasets_complete.csv",
+    uberon_json: Optional[str] = None,
+    organism: Optional[str] = None,
+    no_preprints: bool = False,
+    exclude_cancer: bool = False,
+    exclude_spatial: bool = False,
+    disease: Optional[str] = None,
+) -> dict:
+    """Step 4: Filter datasets by tissue, organism, and study type.
+
+    Parameters
+    ----------
+    output_csv:      Path for the filtered output CSV (required).
+    input_csv:       Input CSV (default: data/all_datasets_complete.csv).
+    uberon_json:     UBERON JSON from resolve_uberon — restricts to datasets
+                     whose tissue column matches any term label in the file.
+    organism:        Filter by organism string (e.g. "Homo sapiens").
+    no_preprints:    If True, exclude preprint-only datasets.
+    exclude_cancer:  If True, exclude datasets with cancer/carcinoma disease.
+    exclude_spatial: If True, exclude spatial transcriptomics datasets
+                     (Visium, MERFISH, Xenium, etc.).
+    disease:         Keep only datasets whose disease column contains this
+                     substring (case-insensitive).
+
+    Returns
+    -------
+    output_file:    Path to the filtered CSV.
+    """
+    from harvester.filter_datasets import run_filter_datasets  # noqa: PLC0415
+
+    _run(
+        run_filter_datasets,
+        input_csv=input_csv,
+        output_csv=output_csv,
+        uberon_json=uberon_json,
+        organism=organism,
+        no_preprints=no_preprints,
+        exclude_cancer=exclude_cancer,
+        exclude_spatial=exclude_spatial,
+        disease=disease,
+    )
+    return {"output_file": output_csv}
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — Count normal cells
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def count_normal_cells(
+    input_csv: str,
+    uberon_json: str,
+    min_age: int = 15,
+) -> dict:
+    """Step 5: Count normal (non-diseased, adult, primary) cells via CellxGene Census.
+
+    For each dataset in input_csv, queries CellxGene Census for cells that:
+      - Are from the specified UBERON tissues
+      - Have disease == 'normal'
+      - Have is_primary_data == True
+      - Are from donors aged >= min_age (fetal/embryo stages excluded)
+
+    Execution
+    ---------
+    If CloudOS environment variables are configured (CLOUDOS_API_KEY,
+    CLOUDOS_WORKSPACE_ID, CLOUDOS_PROJECT_ID, CLOUDOS_WORKFLOW_ID), the
+    job is submitted to Lifebit CloudOS as a Nextflow workflow and this
+    tool blocks until it completes.
+
+    If CloudOS is not configured, the step runs locally. This works for
+    development and small datasets but requires sufficient local memory
+    for CellxGene Census access.
+
+    Parameters
+    ----------
+    input_csv:   Filtered datasets CSV from filter_datasets.
+    uberon_json: UBERON JSON from resolve_uberon.
+    min_age:     Minimum donor age for adult filtering (default 15).
+
+    Returns
+    -------
+    output_file:  Path to the output CSV with a normal_cell_count column added.
+    execution:    "cloudos" or "local" — where the step ran.
+    job_id:       CloudOS job ID (only present when execution == "cloudos").
+    """
+    from harvester.mcp import cloudos_client  # noqa: PLC0415
+
+    base = os.path.splitext(input_csv)[0]
+    output_csv = f"{base}_with_normal_counts.csv"
+
+    if cloudos_client.is_configured():
+        result = cloudos_client.run_via_cloudos(
+            input_csv_path=input_csv,
+            uberon_json_path=uberon_json,
+            min_age=min_age,
+        )
+        return {
+            "output_file": result.get("output_path") or output_csv,
+            "execution": "cloudos",
+            "job_id": result["job_id"],
+        }
+
+    # Local fallback
+    print(
+        "[cellxgene-harvester-mcp] CloudOS not configured — running count_normal_cells locally. "
+        "Set CLOUDOS_API_KEY and related env vars to dispatch to CloudOS.",
+        file=sys.stderr,
+    )
+    from harvester.count_normal_cells import run_count_normal_cells  # noqa: PLC0415
+
+    _run(run_count_normal_cells, input_csv=input_csv, uberon_json=uberon_json, min_age=min_age)
+    return {
+        "output_file": output_csv,
+        "execution": "local",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — Final cleanup
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def final_cleanup(input_csv: str) -> dict:
+    """Step 6: Remove datasets with zero normal cells.
+
+    Reads input_csv and drops any row where normal_cell_count is 0, blank,
+    or non-numeric. Writes the cleaned result alongside the input file.
+
+    Parameters
+    ----------
+    input_csv: CSV with normal_cell_count column (output from count_normal_cells).
+
+    Returns
+    -------
+    output_file:     Path to the final cleaned CSV.
+    """
+    from harvester.final_cleanup import run_final_cleanup  # noqa: PLC0415
+
+    _run(run_final_cleanup, input_csv)
+
+    base = os.path.splitext(input_csv)[0]
+    if base.endswith("_with_normal_counts"):
+        base = base.replace("_with_normal_counts", "")
+    return {"output_file": f"{base}_final.csv"}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    """Start the MCP server.
+
+    Runs in stdio mode by default (for Claude Code / Claude Desktop).
+    To switch to HTTP/SSE for remote deployment, change to:
+        mcp.run(transport="sse", host="0.0.0.0", port=8000)
+    """
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a FastMCP-based MCP server (`src/harvester/mcp/`) that exposes each pipeline step as an AI-callable tool, enabling agents (Claude Code, Claude Desktop, etc.) to orchestrate the full cellxgene-harvester workflow through natural language
- Steps 0–4 and 6 run in-process (lightweight API calls); Step 5 (`count_normal_cells`) dispatches to Lifebit CloudOS as a Nextflow batch job when credentials are configured, with a local fallback for development
- `pyproject.toml` gains `fastmcp` as a core dependency, a `cloudos` optional extra (`cloudos-cli`), and a `cellxgene-harvester-mcp` entry point

## New files

| File | Purpose |
|------|---------|
| `src/harvester/mcp/server.py` | FastMCP stdio server; 7 tools, one per pipeline step |
| `src/harvester/mcp/cloudos_client.py` | CloudOS job submission + polling via cloudos-cli |
| `src/harvester/mcp/__init__.py` | Package marker |

## Install & configure

```bash
# install with CloudOS support
pip install -e ".[cloudos]"

# test server starts
cellxgene-harvester-mcp
```

Add to `~/.claude.json` (Claude Code):

```json
{
  "mcpServers": {
    "cellxgene-harvester": {
      "command": "cellxgene-harvester-mcp",
      "env": {
        "CLOUDOS_API_KEY": "<your-key>",
        "CLOUDOS_WORKSPACE_ID": "<workspace-id>",
        "CLOUDOS_PROJECT_ID": "<project-id>",
        "CLOUDOS_WORKFLOW_ID": "<nextflow-workflow-id>"
      }
    }
  }
}
```

## CloudOS credentials required for Step 5

Step 5 (`count_normal_cells`) requires a Nextflow workflow pre-configured in CloudOS. Without credentials the step runs locally (suitable for development/small datasets).

## NIH NLM migration path

One-line change to switch from local stdio to remote HTTP/SSE:

```python
# current (local)
mcp.run()

# NIH NLM deployment
mcp.run(transport="sse", host="0.0.0.0", port=8000)
```

## Test plan

- [ ] `pip install -e ".[cloudos]"` succeeds
- [ ] `cellxgene-harvester-mcp` starts without errors
- [ ] Tools appear in Claude Code `/mcp` list after adding server config
- [ ] Steps 0–4 and 6 run end-to-end via agent ("find kidney datasets, adults only, no cancer")
- [ ] Step 5 submits a visible job in CloudOS dashboard (when credentials set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)